### PR TITLE
Add constructor for std::tuple

### DIFF
--- a/src/job_submitter.cpp
+++ b/src/job_submitter.cpp
@@ -376,7 +376,7 @@ static std::tuple<int,double,double> wait_for_query_answer(string submitter_name
 
     XBT_INFO("Returning : %d  %f  %f", res->nb_resources, res->processing_time, res->expected_time);
 
-    return {res->nb_resources, res->processing_time, res->expected_time};
+    return std::tuple<int, double, double>(res->nb_resources, res->processing_time, res->expected_time);
 }
 
 
@@ -387,7 +387,6 @@ int batexec_job_launcher_process(int argc, char *argv[])
 
     JobSubmitterProcessArguments * args = (JobSubmitterProcessArguments *) MSG_process_get_data(MSG_process_self());
     BatsimContext * context = args->context;
-
     Workload * workload = context->workloads.at(args->workload_name);
 
     auto & jobs = workload->jobs->jobs();


### PR DESCRIPTION
The compilation error I had:

```
/nix/store/7x4my0kkxvpailqa636g6cf69w3xjjdf-gcc-wrapper-5.4.0/bin/g++    -I/nix/store/as11x4zggjmk4a7z1z1lsx14jhdm5lfp-boost-1.62.0-dev/include -I/nix/store/vhgxg489npq2inxcqhpjf0aixzqzd2f1-gmp-6.1.1-dev/include -I/nix/store/9g0bb4izr53y682ysf1qlx2aarywdrbz-rapidjson -I/nix/store/b9m1vknj8x8qmhrjvfwwrpy7kbi512n9-openssl-1.0.2k-dev/include -I/nix/store/s24pj28v6mfvr7jkwff12z4x4awydy4b-redox/include -I/nix/store/z6krgla6vky1n2mhac9w71lq5310g9s4-hiredis-0.13.3/include -I/nix/store/iysgg4cmb3i9hqvyqwdbp5wj9wr6qb1j-libev-4.22/include -I/nix/store/5dr8lb37b10yblg12s8cszr24xcljlhs-zeromq-4.2.2/include  -g    -Wall -Wextra -std=gnu++11 -o CMakeFiles/batsim.dir/src/job_submitter.cpp.o -c /home/adfaure/Projects/batsim/src/job_submitter.cpp
/home/adfaure/Projects/batsim/src/job_submitter.cpp: In function ‘std::tuple<int, double, double> wait_for_query_answer(std::__cxx11::string)’:
/home/adfaure/Projects/batsim/src/job_submitter.cpp:380:69: error: converting to ‘std::tuple<int, double, double>’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {int&, double&, double&}; <template-parameter-2-2> = void; _Elements = {int, double, double}]’
  return {res->nb_resources, res->processing_time, res->expected_time};
```

The full log generated by `make`:
```
$make VERBOSE=1
/nix/store/04ksj309b1v76ykgygnkxfdqfn4walrr-cmake-3.7.2/bin/cmake -H/home/adfaure/Projects/batsim -B/home/adfaure/Projects/batsim/build --check-build-system CMakeFiles/Makefile.cmake 0
/nix/store/04ksj309b1v76ykgygnkxfdqfn4walrr-cmake-3.7.2/bin/cmake -E cmake_progress_start /home/adfaure/Projects/batsim/build/CMakeFiles /home/adfaure/Projects/batsim/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/home/adfaure/Projects/batsim/build'
make -f CMakeFiles/batsim.dir/build.make CMakeFiles/batsim.dir/depend
make[2]: Entering directory '/home/adfaure/Projects/batsim/build'
cd /home/adfaure/Projects/batsim/build && /nix/store/04ksj309b1v76ykgygnkxfdqfn4walrr-cmake-3.7.2/bin/cmake -E cmake_depends "Unix Makefiles" /home/adfaure/Projects/batsim /home/adfaure/Projects/batsim /home/adfaure/Projects/batsim/build /home/adfaure/Projects/batsim/build /home/adfaure/Projects/batsim/build/CMakeFiles/batsim.dir/DependInfo.cmake --color=
Dependee "/home/adfaure/Projects/batsim/src/job_submitter.cpp" is newer than depender "CMakeFiles/batsim.dir/src/job_submitter.cpp.o".
Clearing dependencies in "/home/adfaure/Projects/batsim/build/CMakeFiles/batsim.dir/depend.make".
Scanning dependencies of target batsim
make[2]: Leaving directory '/home/adfaure/Projects/batsim/build'
make -f CMakeFiles/batsim.dir/build.make CMakeFiles/batsim.dir/build
make[2]: Entering directory '/home/adfaure/Projects/batsim/build'
[  5%] Building CXX object CMakeFiles/batsim.dir/src/job_submitter.cpp.o
/nix/store/7x4my0kkxvpailqa636g6cf69w3xjjdf-gcc-wrapper-5.4.0/bin/g++    -I/nix/store/as11x4zggjmk4a7z1z1lsx14jhdm5lfp-boost-1.62.0-dev/include -I/nix/store/vhgxg489npq2inxcqhpjf0aixzqzd2f1-gmp-6.1.1-dev/include -I/nix/store/9g0bb4izr53y682ysf1qlx2aarywdrbz-rapidjson -I/nix/store/b9m1vknj8x8qmhrjvfwwrpy7kbi512n9-openssl-1.0.2k-dev/include -I/nix/store/s24pj28v6mfvr7jkwff12z4x4awydy4b-redox/include -I/nix/store/z6krgla6vky1n2mhac9w71lq5310g9s4-hiredis-0.13.3/include -I/nix/store/iysgg4cmb3i9hqvyqwdbp5wj9wr6qb1j-libev-4.22/include -I/nix/store/5dr8lb37b10yblg12s8cszr24xcljlhs-zeromq-4.2.2/include  -g    -Wall -Wextra -std=gnu++11 -o CMakeFiles/batsim.dir/src/job_submitter.cpp.o -c /home/adfaure/Projects/batsim/src/job_submitter.cpp
/home/adfaure/Projects/batsim/src/job_submitter.cpp: In function ‘std::tuple<int, double, double> wait_for_query_answer(std::__cxx11::string)’:
/home/adfaure/Projects/batsim/src/job_submitter.cpp:380:69: error: converting to ‘std::tuple<int, double, double>’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {int&, double&, double&}; <template-parameter-2-2> = void; _Elements = {int, double, double}]’
  return {res->nb_resources, res->processing_time, res->expected_time};
                                                                     ^
make[2]: *** [CMakeFiles/batsim.dir/build.make:135: CMakeFiles/batsim.dir/src/job_submitter.cpp.o] Error 1
make[2]: Leaving directory '/home/adfaure/Projects/batsim/build'
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/batsim.dir/all] Error 2
make[1]: Leaving directory '/home/adfaure/Projects/batsim/build'
make: *** [Makefile:139: all] Error 2
```

Information about the cmake:

```
$ cmake --version
cmake version 3.7.2
```
```
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /nix/store/7x4my0kkxvpailqa636g6cf69w3xjjdf-gcc-wrapper-5.4.0/bin/gcc
-- Check for working C compiler: /nix/store/7x4my0kkxvpailqa636g6cf69w3xjjdf-gcc-wrapper-5.4.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /nix/store/7x4my0kkxvpailqa636g6cf69w3xjjdf-gcc-wrapper-5.4.0/bin/g++
-- Check for working CXX compiler: /nix/store/7x4my0kkxvpailqa636g6cf69w3xjjdf-gcc-wrapper-5.4.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting build type to 'Debug' as none was specified.
-- Looking for lib SimGrid
-- Looking for lib SimGrid - found
-- Simgrid version : 3.1
-- Found Tesh: /nix/store/fwm5shhj7p6rrvpdaz5zv202zvbdcbp1-simgrid-batsim/bin/tesh
-- Boost version: 1.62.0
-- Found the following Boost libraries:
--   system
--   filesystem
--   regex
--   locale
-- GMP libs: /nix/store/ih48ry2nd9wi6npgx4m2k26lfq3psngm-gmp-6.1.1/lib/libgmp.so /nix/store/ih48ry2nd9wi6npgx4m2k26lfq3psngm-gmp-6.1.1/lib/libgmpxx.so
-- Found GMP: /nix/store/vhgxg489npq2inxcqhpjf0aixzqzd2f1-gmp-6.1.1-dev/include  
-- Found rapidjson header files in /nix/store/9g0bb4izr53y682ysf1qlx2aarywdrbz-rapidjson
-- Found OpenSSL: /nix/store/9x03gg4ia71qv6ffj12q4frcm39rq65k-openssl-1.0.2k/lib/libssl.so;/nix/store/9x03gg4ia71qv6ffj12q4frcm39rq65k-openssl-1.0.2k/lib/libcrypto.so (found version "1.0.2k") 
-- Found redox: /nix/store/s24pj28v6mfvr7jkwff12z4x4awydy4b-redox/lib64/libredox.so  
-- Found hiredis: /nix/store/z6krgla6vky1n2mhac9w71lq5310g9s4-hiredis-0.13.3/lib/libhiredis.so  
-- Found libev: /nix/store/iysgg4cmb3i9hqvyqwdbp5wj9wr6qb1j-libev-4.22/lib/libev.so  
-- Found ZMQ: /nix/store/5dr8lb37b10yblg12s8cszr24xcljlhs-zeromq-4.2.2/lib/libzmq.so  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/adfaure/Projects/batsim/build
```
