### PR TITLE
[test] add scheduler energywatcher in the tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -117,7 +117,7 @@ def pytest_generate_tests(metafunc):
         "py_filler_events": "fillerSchedWithEvents",
     }
     basic_algorithms = ["fcfs", "easyfast", "filler"]
-    energy_algorithms = ["sleeper"] #fixme: enable "energywatcher" once algo fixed
+    energy_algorithms = ["sleeper", "energywatcher"]
     metadata_algorithms = ['filler', 'submitter']
 
     # External Events


### PR DESCRIPTION
I was investigating how energy accounting is working for multicore machines in Batsim and I saw [this fixme in batsim tests](https://github.com/oar-team/batsim/blob/master/test/conftest.py#L120). It says that the basched scheduler `energywatcher` needs to be fixed, which I did in [this commit](https://framagit.org/Mema5/batsched/-/commit/a11ab8ec854d2212d5d0f9432e3d70aaf41e28f4) in my fork of batsched.

## How to check that it works
Build my version of batsched:
```shell
$ cd /tmp/ && git clone https://framagit.org/Mema5/batsched.git
$ cd batsched/
$ git checkout fix_energy_watcher
$ nix-shell -A batsched # enter a Nix environment with all dependencies managed
$ meson build # generate a build directory
$ ninja -C build # compile the project into the build directory
```
In another terminal, in this branch of batsim:
```shell
$ nix-shell -A integration_tests # environment with master version of batsched
$ pytest test/test_energy.py # test does not pass
$ export PATH="/tmp/batsched/build:${PATH}" # use the version of batsched with the bugfix
$ which batsched # should answer /tmp/batsched/build/batsched
$ pytest test/test_energy.py # the test passes :)
```

## Checklist

Branch name.
- [x] Descriptive and short
- [x] Use hyphens to separate words

Branch content.
- [x] Only dedicated to the problem.
- [x] Based on Batsim's official master branch.
- [x] Straightforward. Just a sequence of commits. Does not contain merge commits.
- [x] Test results are not worse than before. [How to run Batsim tests?](https://batsim.readthedocs.io/en/latest/howto-test.html)
