### PR TITLE
Fix precision loss on consumed_energy.csv

### DIFF
--- a/src/export.cpp
+++ b/src/export.cpp
@@ -845,12 +845,12 @@ long double EnergyConsumptionTracer::add_entry(double date, char event_type)
 
     if (epower != -1)
     {
-        nb_printed = snprintf(buf, buf_size, "%g,%Lg,%c,%Lg,%g\n",
+        nb_printed = snprintf(buf, buf_size, "%lf,%Lf,%c,%Lf,%lf\n",
                               date, energy, event_type, wattmin, static_cast<double>(epower));
     }
     else
     {
-        nb_printed = snprintf(buf, buf_size, "%g,%Lg,%c,%Lg,NA\n",
+        nb_printed = snprintf(buf, buf_size, "%lf,%Lf,%c,%Lf,NA\n",
                               date, energy, event_type, wattmin);
     }
     xbt_assert(nb_printed < buf_size - 1,


### PR DESCRIPTION
Fix precision loss in consumed_energy.csv
Formatting with C99 "%g" cuts by 2 the precision of doubles, which is used to store dates.  
Now "%lf" is used instead, which is the standard format for doubles.

**Checklist**  

Branch name.
- [x] Descriptive and short
- [x] Use hyphens to separate words

Branch content.
- [x] Only dedicated to the problem.
- [x] Based on Batsim's official master branch.
- [x] Straightforward. Just a sequence of commits. Does not contain merge commits.
- [x] Test results are not worse than before. [How to run Batsim tests?](https://batsim.readthedocs.io/en/latest/howto-test.html)
