### PR TITLE
Add parallel utilization

### DIFF
--- a/platforms/energy_platform_homogeneous.xml
+++ b/platforms/energy_platform_homogeneous.xml
@@ -11,25 +11,25 @@
     When switching from a computing state to the state 1, passing by the virtual pstate 2 is mandatory to simulate the time and energy consumed by the switch off.
     When switching from the state 1 to a computing state, passing by the virtual pstate 3 is mandatory to simulate the time and energy consumed by the switch on.
      -->
-    <host id="Mercury" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" >
+    <host id="Mercury" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" core="100">
         <prop id="wattage_per_state" value="30.0:30.0:100.0, 9.75:9.75:9.75, 200.996721311:200.996721311:200.996721311, 425.1743849:425.1743849:425.1743849" />
         <prop id="wattage_off" value="9.75" />
         <prop id="sleep_pstates" value="1:2:3" />
     </host>
 
-    <host id="Venus" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" >
+    <host id="Venus" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" core="100">
         <prop id="wattage_per_state" value="30.0:30.0:100.0, 9.75:9.75:9.75, 200.996721311:200.996721311:200.996721311, 425.1743849:425.1743849:425.1743849" />
         <prop id="wattage_off" value="9.75" />
         <prop id="sleep_pstates" value="1:2:3" />
     </host>
 
-    <host id="Earth" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" >
+    <host id="Earth" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" core="100">
         <prop id="wattage_per_state" value="30.0:30.0:100.0, 9.75:9.75:9.75, 200.996721311:200.996721311:200.996721311, 425.1743849:425.1743849:425.1743849" />
         <prop id="wattage_off" value="9.75" />
         <prop id="sleep_pstates" value="1:2:3" />
     </host>
 
-    <host id="Mars" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" >
+    <host id="Mars" speed="100.0Mf, 1e-9Mf, 0.5f, 0.05f" pstate="0" core="100">
         <prop id="wattage_per_state" value="30.0:30.0:100.0, 9.75:9.75:9.75, 200.996721311:200.996721311:200.996721311, 425.1743849:425.1743849:425.1743849" />
         <prop id="wattage_off" value="9.75" />
         <prop id="sleep_pstates" value="1:2:3" />

--- a/src/profiles.cpp
+++ b/src/profiles.cpp
@@ -374,6 +374,17 @@ ProfilePtr Profile::from_json(const std::string & profile_name,
                        "elements must be non-negative", error_prefix.c_str(), profile_name.c_str());
         }
 
+        // get and check util. Default to full utilization if not exists
+        if (json_desc.HasMember("util")) {
+            xbt_assert(json_desc["util"].IsNumber(), "%s: profile '%s' has a non-number 'util' field", 
+                       error_prefix.c_str(), profile_name.c_str());
+            data->util = json_desc["util"].GetDouble();
+            xbt_assert(data->util > 0.0 && data->util <= 1.0 , "%s: profile '%s' has an invalid 'util' field (%g)",
+                       error_prefix.c_str(), profile_name.c_str(), data->util);
+        } else {
+            data->util = 1.0;
+        }
+
         profile->data = data;
     }
     else if (profile_type == "parallel_homogeneous")
@@ -404,6 +415,16 @@ ProfilePtr Profile::from_json(const std::string & profile_name,
         xbt_assert(data->com >= 0, "%s: profile '%s' has a non-positive 'com' field (%g)",
                    error_prefix.c_str(), profile_name.c_str(), data->com);
 
+        if (json_desc.HasMember("util")) {
+            xbt_assert(json_desc["util"].IsNumber(), "%s: profile '%s' has a non-number 'util' field", 
+                        error_prefix.c_str(), profile_name.c_str());
+            data->util = json_desc["util"].GetDouble();
+            xbt_assert(data->util > 0.0 && data->util <= 1.0 , "%s: profile '%s' has an invalid 'util' field (%g)",
+                        error_prefix.c_str(), profile_name.c_str(), data->util);
+        } else {
+            data->util = 1.0;
+        }   
+
         profile->data = data;
     }
     else if (profile_type == "parallel_homogeneous_total")
@@ -433,6 +454,16 @@ ProfilePtr Profile::from_json(const std::string & profile_name,
         data->com = json_desc["com"].GetDouble();
         xbt_assert(data->com >= 0, "%s: profile '%s' has a non-positive 'com' field (%g)",
                    error_prefix.c_str(), profile_name.c_str(), data->com);
+
+        if (json_desc.HasMember("util")) {
+            xbt_assert(json_desc["util"].IsNumber(), "%s: profile '%s' has a non-number 'util' field", 
+                        error_prefix.c_str(), profile_name.c_str());
+            data->util = json_desc["util"].GetDouble();
+            xbt_assert(data->util > 0.0 && data->util <= 1.0 , "%s: profile '%s' has an invalid 'util' field (%g)",
+                        error_prefix.c_str(), profile_name.c_str(), data->util);
+        } else {
+            data->util = 1.0;
+        } 
 
         profile->data = data;
     }

--- a/src/profiles.hpp
+++ b/src/profiles.hpp
@@ -102,6 +102,7 @@ struct ParallelProfileData
     unsigned int nb_res;    //!< The number of resources
     double * cpu = nullptr; //!< The computation vector
     double * com = nullptr; //!< The communication matrix
+    double util; //!< The cpu utilization on each node
 };
 
 /**
@@ -111,6 +112,7 @@ struct ParallelHomogeneousProfileData
 {
     double cpu; //!< The computation amount on each node
     double com; //!< The communication amount between each pair of nodes
+    double util; //!< The cpu utilization on each node
 };
 
 /**
@@ -120,6 +122,7 @@ struct ParallelHomogeneousTotalAmountProfileData
 {
     double cpu; //!< The computation amount to spread over the nodes
     double com; //!< The communication amount to spread over each pair of nodes
+    double util; //!< The cpu utilization on each node
 };
 /**
  * @brief The data associated to DELAY profiles

--- a/src/task_execution.cpp
+++ b/src/task_execution.cpp
@@ -21,11 +21,13 @@ using namespace roles;
  *        parallel task profile. Also set the prefix name of the task.
  * @param[out] computation_amount the computation matrix to be simulated by the parallel task
  * @param[out] communication_amount the communication matrix to be simulated by the parallel task
+ * @param[out] utilization the max CPU utilization to be simulated (as a decimal between 0 and 1)
  * @param[in] nb_res the number of resources the task have to run on
  * @param[in] profile_data the profile data
  */
 void generate_parallel_task(std::vector<double>& computation_amount,
                             std::vector<double>& communication_amount,
+                            double& utilization,
                             unsigned int nb_res,
                             void * profile_data)
 {
@@ -42,6 +44,7 @@ void generate_parallel_task(std::vector<double>& computation_amount,
     // Retrieve the matrices from the profile
     memcpy(computation_amount.data(), data->cpu, sizeof(double) * nb_res);
     memcpy(communication_amount.data(), data->com, sizeof(double) * nb_res * nb_res);
+    utilization = data->util;
 }
 
 /**
@@ -49,11 +52,13 @@ void generate_parallel_task(std::vector<double>& computation_amount,
  *        parallel homogeneous task profile. Also set the prefix name of the task.
  * @param[out] computation_amount the computation matrix to be simulated by the parallel task
  * @param[out] communication_amount the communication matrix to be simulated by the parallel task
+ * @param[out] utilization the max CPU utilization to be simulated (as a decimal between 0 and 1)
  * @param[in] nb_res the number of resources the task have to run on
  * @param[in] profile_data the profile data
  */
 void generate_parallel_homogeneous(std::vector<double>& computation_amount,
                                    std::vector<double>& communication_amount,
+                                   double& utilization,
                                    unsigned int nb_res,
                                    void * profile_data)
 {
@@ -61,6 +66,7 @@ void generate_parallel_homogeneous(std::vector<double>& computation_amount,
 
     double cpu = data->cpu;
     double com = data->com;
+    utilization = data->util;
 
     // Prepare buffers
     computation_amount.reserve(nb_res);
@@ -100,6 +106,7 @@ void generate_parallel_homogeneous(std::vector<double>& computation_amount,
  *
  * @param[out] computation_amount the computation matrix to be simulated by the parallel task
  * @param[out] communication_amount the communication matrix to be simulated by the parallel task
+ * @param[out] utilization the max CPU utilization to be simulated (as a decimal between 0 and 1)
  * @param[in] nb_res the number of resources the task have to run on
  * @param[in] profile_data the profile data
  *
@@ -109,6 +116,7 @@ void generate_parallel_homogeneous(std::vector<double>& computation_amount,
  */
 void generate_parallel_homogeneous_total_amount(std::vector<double>& computation_amount,
                                                 std::vector<double>& communication_amount,
+                                                double& utilization,
                                                 unsigned int nb_res,
                                                 void * profile_data)
 {
@@ -147,6 +155,8 @@ void generate_parallel_homogeneous_total_amount(std::vector<double>& computation
             }
         }
     }
+
+    utilization = data->util;
 }
 
 /**
@@ -155,6 +165,7 @@ void generate_parallel_homogeneous_total_amount(std::vector<double>& computation
  *
  * @param[out] computation_amount the computation matrix to be simulated by the parallel task
  * @param[out] communication_amount the communication matrix to be simulated by the parallel task
+ * @param[out] utilization the max CPU utilization to be simulated (as a decimal between 0 and 1)
  * @param[in,out] hosts_to_use the list of host to be used by the task
  * @param[in] storage_mapping mapping from label given in the profile and machine id
  * @param[in] profile_data the profile data
@@ -165,6 +176,7 @@ void generate_parallel_homogeneous_total_amount(std::vector<double>& computation
  */
 void generate_parallel_homogeneous_with_pfs(std::vector<double>& computation_amount,
                                             std::vector<double>& communication_amount,
+                                            double& utilization,
                                             std::vector<simgrid::s4u::Host*> & hosts_to_use,
                                             const std::map<std::string, int> * storage_mapping,
                                             void * profile_data,
@@ -243,6 +255,8 @@ void generate_parallel_homogeneous_with_pfs(std::vector<double>& computation_amo
             }
         }
     }
+
+    utilization = 1.0;
 }
 
 /**
@@ -253,6 +267,7 @@ void generate_parallel_homogeneous_with_pfs(std::vector<double>& computation_amo
  * name of the task.
  * @param[out] computation_amount the computation matrix to be simulated by the parallel task
  * @param[out] communication_amount the communication matrix to be simulated by the parallel task
+ * @param[out] utilization the max CPU utilization to be simulated (as a decimal between 0 and 1)
  * @param[in,out] hosts_to_use the list of host to be used by the task
  * @param[in] storage_mapping mapping from label given in the profile and machine id
  * @param[in] profile_data the profile data
@@ -260,6 +275,7 @@ void generate_parallel_homogeneous_with_pfs(std::vector<double>& computation_amo
  */
 void generate_data_staging_task(std::vector<double>&  computation_amount,
                                 std::vector<double>& communication_amount,
+                                double& utilization,
                                 std::vector<simgrid::s4u::Host*> & hosts_to_use,
                                 const std::map<std::string, int> * storage_mapping,
                                 void * profile_data,
@@ -330,12 +346,15 @@ void generate_data_staging_task(std::vector<double>&  computation_amount,
             }
         }
     }
+
+    utilization = 1.0;
 }
 
 /**
  * @brief Debug print of a parallel task (via XBT_DEBUG)
  * @param[in] computation_vector The ptask computation vector
  * @param[in] communication_matrix The ptask communication matrix
+ * @param[in] utilization the max CPU utilization d
  * @param[in] nb_res The number of hosts involved in the parallel task
  * @param[in] alloc The resource ids allocated for the parallel task
  * @param[in] mapping The mapping between executor id and resource id, if any
@@ -374,6 +393,7 @@ void debug_print_ptask(const std::vector<double>& computation_vector,
  * @brief
  * @param[out] computation_vector The computation vector to be simulated by the parallel task
  * @param[out] communication_matrix The communication matrix to be simulated by the parallel task
+ * @param[out] utilization the max CPU utilization to be simulated (as a decimal between 0 and 1)
  * @param[in,out] hosts_to_use The list of host to be used by the task
  * @param[in] profile The profile to be converted to a compute/comm matrix
  * @param[in] storage_mapping The storage mapping
@@ -381,6 +401,7 @@ void debug_print_ptask(const std::vector<double>& computation_vector,
  */
 void generate_matrices_from_profile(std::vector<double>& computation_vector,
                                     std::vector<double>& communication_matrix,
+                                    double& utilization,
                                     std::vector<simgrid::s4u::Host*> & hosts_to_use,
                                     ProfilePtr profile,
                                     const std::map<std::string, int> * storage_mapping,
@@ -396,24 +417,28 @@ void generate_matrices_from_profile(std::vector<double>& computation_vector,
     case ProfileType::PARALLEL:
         generate_parallel_task(computation_vector,
                                    communication_matrix,
+                                   utilization,
                                    nb_res,
                                    profile->data);
         break;
     case ProfileType::PARALLEL_HOMOGENEOUS:
         generate_parallel_homogeneous(computation_vector,
                                           communication_matrix,
+                                          utilization,
                                           nb_res,
                                           profile->data);
         break;
     case ProfileType::PARALLEL_HOMOGENEOUS_TOTAL_AMOUNT:
         generate_parallel_homogeneous_total_amount(computation_vector,
                                                        communication_matrix,
+                                                       utilization,
                                                        nb_res,
                                                        profile->data);
         break;
     case ProfileType::PARALLEL_HOMOGENEOUS_PFS:
         generate_parallel_homogeneous_with_pfs(computation_vector,
                                                    communication_matrix,
+                                                   utilization,
                                                    hosts_to_use,
                                                    storage_mapping,
                                                    profile->data,
@@ -422,6 +447,7 @@ void generate_matrices_from_profile(std::vector<double>& computation_vector,
     case ProfileType::DATA_STAGING:
         generate_data_staging_task(computation_vector,
                                         communication_matrix,
+                                        utilization,
                                         hosts_to_use,
                                         storage_mapping,
                                         profile->data,
@@ -462,6 +488,60 @@ void check_ptask_execution_permission(const IntervalSet & alloc,
     }
 }
 
+/**
+ * @brief
+ * @param[in, out] computation_vector The computation vector to be simulated by the parallel task
+ * @param[in, out] communication_matrix The communication matrix to be simulated by the parallel task
+ * @param[in,out] hosts_to_use The list of host to be used by the task
+ */
+void replicate_for_cores(std::vector<double>& computation_vector,
+                         std::vector<double>& communication_matrix,
+                         std::vector<simgrid::s4u::Host*> & hosts_to_use,
+                         double usage)
+{
+    // compute how many cores should be used depending on usage and on which host is used
+    const double nb_cores = simgrid::s4u::this_actor::get_host()->get_core_count();
+    const int nb_cores_to_use = std::max(round(usage * nb_cores), 1.0); // use at least 1 core, otherwise using flops is impossible
+    const int nb_hosts = hosts_to_use.size();
+
+    std::vector<simgrid::s4u::Host*> hosts_copy(hosts_to_use);
+    std::vector<double> computation_copy(computation_vector);
+    std::vector<double> communication_copy(communication_matrix);
+    hosts_to_use.reserve(nb_cores_to_use * nb_hosts);
+    computation_vector.reserve(nb_cores_to_use * nb_hosts);
+
+    for (int i = 0; i < nb_cores_to_use - 1; ++i) {
+        for (auto host : hosts_copy) {
+            hosts_to_use.push_back(host);
+        }
+    }
+
+    for (int i = 0; i < nb_cores_to_use - 1; ++i) {
+        for (auto computation : computation_copy) {
+            computation_vector.push_back(computation);
+        }
+    }
+
+    if(!communication_matrix.empty()) {
+        communication_matrix.clear();
+        communication_matrix.reserve(nb_cores_to_use * nb_hosts * nb_cores_to_use * nb_cores);
+        for(int row = 0; row < nb_hosts; row++) {
+            for(int col = 0; col < nb_hosts; col++) {
+                communication_matrix.push_back(communication_copy[(row * nb_hosts) + col]);
+            }
+            for(int col = nb_hosts; col < (nb_cores_to_use - 1) * nb_hosts; col++) {
+                communication_matrix.push_back(0);
+            }
+        }
+
+        for(int row = nb_hosts; row < (nb_cores_to_use - 1) * nb_hosts; row++) {
+            for(int col = 0; col < nb_cores_to_use * nb_hosts; col++) {
+                communication_matrix.push_back(0);
+            }
+        }
+    }
+}
+
 int execute_parallel_task(BatTask * btask,
                      const SchedulingAllocation* allocation,
                      double * remaining_time,
@@ -472,6 +552,7 @@ int execute_parallel_task(BatTask * btask,
 
     std::vector<double> computation_vector;
     std::vector<double> communication_matrix;
+    double utilization;
 
     string task_name = profile_type_to_string(profile->type) + '_' + static_cast<JobPtr>(btask->parent_job)->id.to_string() +
                        "_" + btask->profile->name;
@@ -480,6 +561,7 @@ int execute_parallel_task(BatTask * btask,
 
     generate_matrices_from_profile(computation_vector,
                                   communication_matrix,
+                                  utilization,
                                   hosts_to_use,
                                   profile,
                                   & allocation->storage_mapping,
@@ -500,6 +582,7 @@ int execute_parallel_task(BatTask * btask,
         std::vector<simgrid::s4u::Host*> io_hosts = allocation->io_hosts;
         generate_matrices_from_profile(io_computation_vector,
                                       io_communication_matrix,
+                                      utilization,
                                       io_hosts,
                                       io_profile,
                                       nullptr,
@@ -639,6 +722,10 @@ int execute_parallel_task(BatTask * btask,
 
     simgrid::s4u::ExecPtr ptask = simgrid::s4u::this_actor::exec_init(hosts_to_use, computation_vector, communication_matrix);
     ptask->set_name(task_name.c_str());
+
+    // double flops = ptask->get_host()->get_speed() * utilization;
+    // XBT_DEBUG("Setting utilization of '%s' on %zu resources to %g", task_name.c_str(), hosts_to_use.size(), flops);
+    // ptask->set_bound(flops); // Set bound can only be set per task not per host
 
     // Keep track of the task to get information on kill
     btask->ptask = ptask;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -62,6 +62,7 @@ def pytest_generate_tests(metafunc):
         "cluster512_pfs": "cluster512_pfs.xml",
         "energy128notopo": "energy_platform_homogeneous_no_net_128.xml",
         "energy128cluster": "cluster_energy_128.xml",
+        "energysmall": "energy_platform_homogeneous.xml", 
         "properties_platform": "properties_example.xml",
     }
     energy_platforms = ["energy128notopo", "energy128cluster"]
@@ -91,8 +92,9 @@ def pytest_generate_tests(metafunc):
         "usagetrace": "test_usage_trace.json",
         "walltime": "test_walltime.json",
         "walltimesmpi": "test_walltime_smpi.json",
+        "parallel_usage": "test_parallel_usage.json"
     }
-    one_job_workloads = ["delay1", "compute1", "computetot1"]
+    one_job_workloads = ["delay1", "compute1", "computetot1", "compute1util"]
     small_workloads = ["delays", "delaysequences", "mixed"]
     smpi_workloads = ["smpicomp1", "smpicomp2", "smpimapping", "smpimixed", "smpicollectives"]
     dynsub_workloads = ["delay1", "mixed"]
@@ -148,10 +150,12 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('properties_platform', generate_platforms(platform_dir, platforms_def, ['properties_platform']))
     if 'usage_trace_platform' in metafunc.fixturenames:
         metafunc.parametrize('usage_trace_platform', generate_platforms(platform_dir, platforms_def, ['smallusage']))
+    if 'energy_small_platform' in metafunc.fixturenames:
+        metafunc.parametrize('energy_small_platform', generate_platforms(platform_dir, platforms_def, ['energysmall']))
 
     # Workloads
     if 'workload' in metafunc.fixturenames:
-        metafunc.parametrize('workload', generate_workloads(workload_dir, workloads_def, [key for key in workload_def]))
+        metafunc.parametrize('workload', generate_workloads(workload_dir, workloads_def, [key for key in workloads_def]))
     if 'workflow' in metafunc.fixturenames:
         metafunc.parametrize('workflow', generate_workloads(workload_dir, workloads_def, [key for key in workflows]))
     if 'tuto_stencil_workload' in metafunc.fixturenames:
@@ -184,6 +188,8 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('delaysequences_workload', generate_workloads(workload_dir, workloads_def, ['delaysequences']))
     if 'mixed_workload' in metafunc.fixturenames:
         metafunc.parametrize('mixed_workload', generate_workloads(workload_dir, workloads_def, ['mixed']))
+    if 'parallel_usage_workload' in metafunc.fixturenames:
+        metafunc.parametrize('parallel_usage_workload', generate_workloads(workload_dir, workloads_def, ["parallel_usage"]))
 
     # External Events
     if 'simple_events' in metafunc.fixturenames:

--- a/test/test_parallel_usage.py
+++ b/test/test_parallel_usage.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+'''Usage trace tests.
+
+These tests check that the energy consumption of usage trace profiles are the expected ones.
+'''
+import pandas as pd
+import pytest
+from helper import *
+
+widle = 30
+wmin = 30
+wmax = 90
+
+def joule_prediction(time, wattmin, wattmax, usage):
+    return time*(wattmin + (wattmax-wattmin)*usage)
+
+def check_ok_bool(row):
+    if int(row['execution_time']) != int(row['expected_execution_time']):
+        return False
+
+    if int(row['consumed_energy']) != int(row['expected_consumed_energy']):
+        return False
+
+    return True
+
+def check_ok(row):
+    return int(check_ok_bool(row))
+
+def usage_trace(platform, workload, algorithm):
+    test_name = f'paralleluage-{algorithm.name}-{platform.name}-{workload.name}'
+    output_dir, robin_filename, _ = init_instance(test_name)
+
+    if algorithm.sched_implem != 'batsched': raise Exception('This test only supports batsched for now')
+
+    batcmd = gen_batsim_cmd(platform.filename, workload.filename, output_dir, "--energy")
+    instance = RobinInstance(output_dir=output_dir,
+        batcmd=batcmd,
+        schedcmd=f"batsched -v '{algorithm.sched_algo_name}'",
+        simulation_timeout=30, ready_timeout=5,
+        success_timeout=10, failure_timeout=0
+    )
+
+    instance.to_file(robin_filename)
+    ret = run_robin(robin_filename)
+    if ret.returncode != 0: raise Exception(f'Bad robin return code ({ret.returncode})')
+
+
+def test_usage_trace(energy_small_platform, parallel_usage_workload, fcfs_algorithm):
+    usage_trace(energy_small_platform, parallel_usage_workload, fcfs_algorithm)

--- a/workloads/test_parallel_usage.json
+++ b/workloads/test_parallel_usage.json
@@ -1,0 +1,37 @@
+{
+    "nb_res": 4,
+    "jobs": [
+        {"id":1, "subtime":0, "walltime": 100, "res": 4, "profile": "low"},
+        {"id":2, "subtime":0, "walltime": 100, "res": 4, "profile": "high"},
+
+        {"id":3, "subtime":0, "walltime": 100, "res": 4, "profile": "comm_bound_low"},
+        {"id":4, "subtime":0, "walltime": 100, "res": 4, "profile": "comm_bound_high"}
+    ],
+
+    "profiles": {
+        "low": {
+            "type": "parallel_homogeneous",
+            "cpu": 1e9,
+            "com": 1e5,
+            "util": 0.1
+        },
+        "high": {
+            "type": "parallel_homogeneous",
+            "cpu": 1e9,
+            "com": 1e5,
+            "util": 1.0
+        },
+        "comm_bound_low": {
+            "type": "parallel_homogeneous",
+            "cpu": 0,
+            "com": 1e5,
+            "util": 0.1
+        },
+        "comm_bound_high": {
+            "type": "parallel_homogeneous",
+            "cpu": 0,
+            "com": 1e5,
+            "util": 1.0
+        }
+    }
+}


### PR DESCRIPTION
**Describe what the pull request does**  
Implementation of a utilization field for parallel profile types. This is used so that the parallel job then uses multiple cores of each host (#72). This is an optional field that by default is assumed to be 1. This does not change the behavior of the code when "core" is not defined for the host. When core is set, the parallel job is assumed to use the whole node (which seems to be intuitive).

***Approach***
The number of cores to use is calculated based off utilization in the same way as the usage trace. The computation and host vector are then repeated that number of times. The communication matrix is 0 extended, as if only the first core on the host is communicating across hosts. 

***Limitations***
This could lead to higher overheads when core is set to a high number. Also, currently I support a single utilization number, which was enough for my purposes. It may be convenient to support a utilization per host vector, especially in the parallel profile type.
 
***Alternatives***
Originally, I intended to use the `s4u::Exec::set_bound` method. However, this is not supported for the `L07` model.

**Checklist**  

Branch name.
- [x] Descriptive and short
- [x] Use hyphens to separate words

Branch content.
- [x] Only dedicated to the problem.
- [x] Based on Batsim's official master branch.
- [x] Straightforward. Just a sequence of commits. Does not contain merge commits.
- [x] Test results are not worse than before. [How to run Batsim tests?](https://batsim.readthedocs.io/en/latest/howto-test.html)
